### PR TITLE
fix: add logging services for EfAppDatabase DI resolution

### DIFF
--- a/src/Hosts/Modulus.Host.Avalonia/App.axaml.cs
+++ b/src/Hosts/Modulus.Host.Avalonia/App.axaml.cs
@@ -12,6 +12,7 @@ using Modulus.Host.Avalonia.Shell.Views;
 using Modulus.Sdk;
 using Modulus.UI.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.IO;
@@ -53,6 +54,9 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             var services = new ServiceCollection();
+            
+            // Add Logging
+            services.AddLogging();
             
             // Module Providers
             var providers = new System.Collections.Generic.List<IModuleProvider>();


### PR DESCRIPTION
Fix Avalonia host startup failure caused by missing ILogger registration.

## Problem
\\\
System.InvalidOperationException: Unable to resolve service for type 
'Microsoft.Extensions.Logging.ILogger\1[Modulus.Core.Data.EfAppDatabase]'
\\\

## Solution
Add \services.AddLogging()\ to Avalonia Host service registration.

## Changes
- \src/Hosts/Modulus.Host.Avalonia/App.axaml.cs\: Add logging services