### PR TITLE
Fix dependency graph scattering

### DIFF
--- a/openspec/changes/update-dependency-graph-dependson-only/proposal.md
+++ b/openspec/changes/update-dependency-graph-dependson-only/proposal.md
@@ -1,0 +1,15 @@
+# Change: Use DependsOn as the sole dependency source
+
+## Why
+- Manifest and runtime currently mix manifest-declared dependencies with `[DependsOn]` attributes, producing divergent graphs, inconsistent load order, and scattered diagnostics.
+- A single dependency source simplifies validation, improves determinism, and avoids conflicting declarations.
+
+## What Changes
+- Build module dependency graphs exclusively from `[DependsOn]` attributes on module assemblies; ignore manifest dependency entries.
+- Introduce a unified dependency graph builder used by install, enable, and load flows, with shared detection for missing dependencies, cycles, and version/range mismatches.
+- Perform install-time validation by reading `[DependsOn]` metadata from module assemblies inside the package (without loading into the default ALC) and reject invalid modules.
+- Standardize dependency diagnostics (missing, cycle, version) and persist them in module state/logs; block enabling/loading when the graph is invalid.
+
+## Impact
+- Affected specs: `runtime`
+- Affected code: module installer/loader pipeline, dependency graph builder, manifest processing (dependency fields ignored)

--- a/openspec/changes/update-dependency-graph-dependson-only/specs/runtime/spec.md
+++ b/openspec/changes/update-dependency-graph-dependson-only/specs/runtime/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+### Requirement: Dependency graph from DependsOn attributes
+The runtime MUST build and validate module dependency graphs solely from `[DependsOn]` attributes declared on module assemblies; manifest-declared dependency entries MUST be ignored for ordering and validation.
+
+#### Scenario: Install rejects missing dependency
+- **WHEN** the installer processes a module whose `[DependsOn]` references a module id not present in the install set or already available modules
+- **THEN** installation fails with a missing-dependency diagnostic naming the missing module id
+
+#### Scenario: Install rejects dependency cycles
+- **WHEN** `[DependsOn]` declarations form a cycle
+- **THEN** installation rejects the module set and emits a cycle diagnostic listing the participating modules
+
+#### Scenario: Install rejects unmet version or range
+- **WHEN** a `[DependsOn]` declaration includes a version or range that is not satisfied by the available module version
+- **THEN** installation fails with a version-mismatch diagnostic identifying the expected range and the available version
+
+#### Scenario: Runtime load order uses attribute graph
+- **WHEN** the runtime computes module load or enable order
+- **THEN** it uses a topological order derived from `[DependsOn]` only and fails fast with diagnostics if the graph is invalid

--- a/openspec/changes/update-dependency-graph-dependson-only/tasks.md
+++ b/openspec/changes/update-dependency-graph-dependson-only/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [ ] 1.1 Add `[DependsOn]` metadata reader that extracts module ids and optional versions/ranges without loading assemblies into the default ALC.
+- [ ] 1.2 Build a unified dependency graph builder/service consumed by install, enable, and load flows.
+- [ ] 1.3 Enforce install-time validation using the `[DependsOn]` graph (missing dependency, cycle, unsatisfied version/range).
+- [ ] 1.4 Remove manifest dependency usage from runtime paths; emit warnings if present.
+- [ ] 1.5 Persist standardized dependency diagnostics to module state and logs; block enable/load on invalid graphs.
+- [ ] 1.6 Add tests covering no-deps, missing-deps, cycles, version/range mismatch, and manifest-dependency-ignored cases.


### PR DESCRIPTION
Unify module dependency resolution by exclusively using `[DependsOn]` attributes, eliminating manifest dependencies to ensure consistent graph building and centralized diagnostics.

---
<a href="https://cursor.com/background-agent?bcId=bc-75542b2c-885b-4cae-a4f0-3da3e1a76f64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75542b2c-885b-4cae-a4f0-3da3e1a76f64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

