### PR TITLE
Refactor modulus new to template-based syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ dotnet new install Agibuild.Modulus.Templates
 
 ```bash
 # Create a new module
-modulus new MyModule -t avalonia
+modulus new -n MyModule
 
 # Or use dotnet new
 dotnet new modulus-avalonia -n MyModule
@@ -108,7 +108,7 @@ Modulus provides a comprehensive command-line tool for module development and ma
 
 | Command | Description |
 |---------|-------------|
-| `modulus new <name>` | Create a new module project |
+| `modulus new` | Create a new module project |
 | `modulus build` | Build the module in current directory |
 | `modulus pack` | Build and package as .modpkg |
 | `modulus install <source>` | Install a module |
@@ -118,13 +118,11 @@ Modulus provides a comprehensive command-line tool for module development and ma
 ### Create Module
 
 ```bash
-modulus new MyModule [options]
+modulus new [<template>] -n MyModule [options]
 
 Options:
-  -t, --target <avalonia|blazor>  Target host platform
-  -d, --display-name <name>       Display name in menus
-  -p, --publisher <name>          Publisher name
-  -i, --icon <icon>               Menu icon
+  -n, --name <name>               Module name (PascalCase)
+  -o, --output <dir>              Output directory
   --force                         Overwrite existing
 ```
 
@@ -165,7 +163,7 @@ modulus list --verbose
 ### 1. Create Projects
 
 ```bash
-modulus new MyExtension -t avalonia
+modulus new -n MyExtension
 ```
 
 This creates:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,7 +72,7 @@ dotnet new install Agibuild.Modulus.Templates
 
 ```bash
 # 创建新模块
-modulus new MyModule -t avalonia
+modulus new -n MyModule
 
 # 或使用 dotnet new
 dotnet new modulus-avalonia -n MyModule
@@ -108,7 +108,7 @@ Modulus 提供全面的命令行工具用于模块开发和管理。
 
 | 命令 | 描述 |
 |------|------|
-| `modulus new <name>` | 创建新模块项目 |
+| `modulus new` | 创建新模块项目 |
 | `modulus build` | 在当前目录编译模块 |
 | `modulus pack` | 编译并打包为 .modpkg |
 | `modulus install <source>` | 安装模块 |
@@ -118,13 +118,11 @@ Modulus 提供全面的命令行工具用于模块开发和管理。
 ### 创建模块
 
 ```bash
-modulus new MyModule [options]
+modulus new [<template>] -n MyModule [options]
 
 选项:
-  -t, --target <avalonia|blazor>  目标主机平台
-  -d, --display-name <name>       菜单中显示的名称
-  -p, --publisher <name>          发布者名称
-  -i, --icon <icon>               菜单图标
+  -n, --name <name>               模块名称 (PascalCase)
+  -o, --output <dir>              输出目录
   --force                         覆盖已有文件
 ```
 
@@ -165,7 +163,7 @@ modulus list --verbose
 ### 1. 创建项目
 
 ```bash
-modulus new MyExtension -t avalonia
+modulus new -n MyExtension
 ```
 
 这将创建：

--- a/build/BuildTasks.cs
+++ b/build/BuildTasks.cs
@@ -851,7 +851,7 @@ class BuildTasks : NukeBuild
             LogNormal("");
             LogNormal("To use these packages in module templates:");
             LogNormal("  1. Run 'nuke add-local-source' (if not done)");
-            LogNormal("  2. Run 'modulus new MyModule --target avalonia'");
+            LogNormal("  2. Run 'modulus new -n MyModule'");
             LogNormal("  3. dotnet restore will find packages from local source");
         });
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,48 +35,43 @@ Create a new Modulus module project with all necessary files and structure.
 ### Syntax
 
 ```bash
-modulus new <name> [options]
+modulus new [<template>] -n <name> [options]
 ```
 
 ### Arguments
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `<name>` | Yes | The module name (used for project and namespace) |
+| `<template>` | No | Template name: `module-avalonia` or `module-blazor` (default: `module-avalonia`) |
 
 ### Options
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--target` | `-t` | Target host: `avalonia` or `blazor` | (interactive) |
-| `--display-name` | `-d` | Display name shown in menus | Same as name |
-| `--description` | | Module description | Generated |
-| `--publisher` | `-p` | Publisher name | (interactive) |
-| `--icon` | `-i` | Menu icon (IconKind value) | `Folder` |
-| `--order` | `-o` | Menu order | `100` |
-| `--output` | | Output directory | Current directory |
+| `--name` | `-n` | The module name (used for project and namespace) | (required) |
+| `--output` | `-o` | Output directory | Current directory |
 | `--force` | `-f` | Overwrite existing directory | `false` |
+| `--list` | | List available templates and exit | `false` |
 
-### Available Icons
+### Templates
 
-Common icon values: `Folder`, `Home`, `Settings`, `Terminal`, `Code`, `Database`, `Cloud`, `User`, `Star`, `Heart`, `Search`, `Edit`, `Delete`, `Add`, `Check`, `Close`, `Info`, `Warning`, `Error`
-
-See the full list in `Modulus.UI.Abstractions.IconKind` enum.
+- `module-avalonia`: Modulus module (Avalonia)
+- `module-blazor`: Modulus module (Blazor)
 
 ### Examples
 
 ```bash
-# Interactive mode (prompts for all options)
-modulus new MyModule
+# List templates
+modulus new --list
 
-# Create Avalonia module with all options
-modulus new MyModule -t avalonia -d "My Module" -p "Acme Corp" -i Home
+# Create an Avalonia module (default template)
+modulus new -n MyModule
 
-# Create Blazor module in specific directory
-modulus new MyModule -t blazor --output ./src/Modules/
+# Create a Blazor module in a specific directory
+modulus new module-blazor -n MyModule -o ./src/Modules/
 
 # Overwrite existing project
-modulus new MyModule -t avalonia --force
+modulus new -n MyModule --force
 ```
 
 ### Generated Structure

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ dotnet run --project src/Hosts/Modulus.Host.Avalonia
 Using the CLI:
 
 ```bash
-modulus new MyFirstModule -t avalonia
+modulus new -n MyFirstModule
 cd MyFirstModule
 ```
 

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -60,7 +60,7 @@ dotnet run --project src/Hosts/Modulus.Host.Avalonia
 使用 CLI：
 
 ```bash
-modulus new MyFirstModule -t avalonia
+modulus new -n MyFirstModule
 cd MyFirstModule
 ```
 

--- a/docs/samples/home-mockup-orbital.html
+++ b/docs/samples/home-mockup-orbital.html
@@ -557,7 +557,7 @@
                 </div>
                 <div class="cli-line">
                     <span class="cli-prompt">$</span>
-                    <span class="cli-command">modulus new <span class="cli-highlight">MyModule</span> -t avalonia</span>
+                    <span class="cli-command">modulus new -n <span class="cli-highlight">MyModule</span></span>
                     <span class="cli-comment"># 创建新模块</span>
                 </div>
                 <div class="cli-line">

--- a/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/design.md
+++ b/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/design.md
@@ -1,0 +1,55 @@
+## Context
+
+本变更聚焦于 `modulus new` 的命令行体验，目标是收敛参数面并对齐 `dotnet new` 的使用模型：以 template 选择为主、以通用参数（name/output/force）为辅，避免将模板内部元数据暴露为 CLI 参数。
+
+## Goals / Non-Goals
+
+- Goals
+  - 最小参数面：创建项目只需理解 template + name + output/force
+  - 具备可发现性：支持 `modulus new --list` 列出模板
+  - 默认行为明确：未指定 template 时默认 `module-avalonia`
+  - 立即删除冗余参数（breaking change）
+- Non-Goals
+  - 不在本变更中引入更多模板（仅 `module-avalonia`/`module-blazor`）
+  - 不在本变更中更改生成的文件内容语义（仅命令行入口与参数映射调整）
+
+## Decisions
+
+### Decision: New syntax
+
+Primary syntax:
+
+```bash
+modulus new [<template>] -n <name> [-o <dir>] [-f] [--list]
+```
+
+- `<template>`: `module-avalonia` / `module-blazor`（可选；缺省时为 `module-avalonia`）
+- `-n|--name`: 模块名（PascalCase）
+- `-o|--output`: 输出目录（默认当前目录）
+- `-f|--force`: 覆盖已有目录
+- `--list`: 列出模板并退出（不创建项目）
+
+### Decision: Immediate removal of legacy options
+
+Deleted options (no compatibility layer):
+- `--target/-t`
+- `--display-name/-d`
+- `--description`
+- `--publisher/-p`
+- `--icon/-i`
+- `--order/-o`
+
+Rationale: 这些参数属于模板内部元数据，应该由生成后修改文件/代码来完成，而不是创建命令的必选理解成本。
+
+## Risks / Trade-offs
+
+- **BREAKING**：脚本/文档中旧语法会失败，需要同步更新测试与文档。
+- 模板元数据不可在创建时通过 CLI 注入，用户需改生成文件（但换来更稳定的命令面）。
+
+## Migration Plan
+
+- Update docs/examples and integration tests to:
+  - `modulus new -n MyModule`（默认 `module-avalonia`）
+  - `modulus new module-blazor -n MyModule`
+
+

--- a/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/proposal.md
+++ b/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/proposal.md
@@ -1,0 +1,31 @@
+# Change: Refactor `modulus new` command surface to dotnet-new style
+
+## Why
+
+当前 `modulus new` 将大量模板元数据（显示名称、发布者、图标、菜单顺序等）暴露为命令行参数，导致参数面过大、难以发现与难以脚本化，也与 `dotnet new` 的最佳实践不一致。
+
+## What Changes
+
+- 将 `modulus new` 重构为 **dotnet-new 风格**：
+  - 以 **template** 驱动创建：`modulus new [<template>] -n <name> ...`
+  - 提供 `--list` 列出可用模板
+  - 未显式指定模板时，默认使用 `module-avalonia`
+- **BREAKING**：移除不必要的参数（立即删除，不做兼容别名/隐藏参数）
+  - 移除：`--target/-t`、`--display-name/-d`、`--description`、`--publisher/-p`、`--icon/-i`、`--order/-o`
+- 统一创建命令的通用参数与语义
+  - `-n|--name`：模块名（PascalCase）
+  - `-o|--output`：输出目录（默认当前目录）
+  - `-f|--force`：覆盖已有目录
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/module-template/spec.md`（CLI 命令语法与行为）
+  - `openspec/specs/cli-testing/spec.md`（new 命令测试用例语法）
+- Affected code (expected):
+  - `src/Modulus.Cli/Commands/NewCommand.cs`（参数定义、解析与行为）
+  - `tests/Modulus.Cli.IntegrationTests/Infrastructure/CliRunner.cs`
+  - `tests/Modulus.Cli.IntegrationTests/Commands/NewCommandTests.cs`
+  - `docs/cli-reference.md`、`docs/getting-started*.md`、`README*.md`（命令示例）
+
+

--- a/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/specs/cli-testing/spec.md
+++ b/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/specs/cli-testing/spec.md
@@ -1,0 +1,41 @@
+# cli-testing Specification (Delta)
+
+## MODIFIED Requirements
+
+### Requirement: CLI Command Tests
+
+CLI 集成测试 SHALL 覆盖所有 CLI 命令的基本功能。
+
+#### Scenario: New command creates module
+- **WHEN** 执行 `modulus new -n TestModule --force`
+- **THEN** 创建包含正确结构的模块目录
+- **AND** 生成 `.sln`、`.csproj`、`extension.vsixmanifest` 等文件
+
+#### Scenario: Build command compiles module
+- **WHEN** 在模块目录执行 `modulus build`
+- **THEN** 编译成功并生成 DLL 文件
+- **AND** 返回退出码 0
+
+#### Scenario: Pack command creates package
+- **WHEN** 在模块目录执行 `modulus pack`
+- **THEN** 生成 `.modpkg` 文件
+- **AND** 包内包含 `extension.vsixmanifest` 和模块 DLL
+
+#### Scenario: Install command registers module
+- **WHEN** 执行 `modulus install <path>.modpkg`
+- **THEN** 解压包到模块目录
+- **AND** 在数据库中注册模块
+- **AND** `modulus list` 显示已安装模块
+
+#### Scenario: Uninstall command removes module
+- **WHEN** 执行 `modulus uninstall <name> --force`
+- **THEN** 从数据库中删除模块记录
+- **AND** `modulus list` 不再显示该模块
+
+#### Scenario: List command shows installed modules
+- **WHEN** 已安装模块后执行 `modulus list`
+- **THEN** 显示模块名称和版本
+- **WHEN** 执行 `modulus list --verbose`
+- **THEN** 额外显示模块 ID、发布者等详细信息
+
+

--- a/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/specs/module-template/spec.md
+++ b/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/specs/module-template/spec.md
@@ -1,0 +1,30 @@
+# module-template Specification (Delta)
+
+## MODIFIED Requirements
+
+### Requirement: CLI Template Command
+
+系统 SHALL 提供 `modulus new` CLI 命令，用于创建 Modulus 模块，并遵循 `dotnet new` 的最佳实践：以模板选择为主、以通用参数为辅，避免暴露模板内部元数据参数。
+
+#### Scenario: Default template is module-avalonia
+- **WHEN** 用户执行 `modulus new -n MyModule`
+- **THEN** 系统使用 `module-avalonia` 模板创建模块
+- **AND** 创建包含 `MyModule.Core` 与 `MyModule.UI.Avalonia` 的解决方案
+
+#### Scenario: Explicit template creates module
+- **WHEN** 用户执行 `modulus new module-blazor -n MyModule`
+- **THEN** 系统使用 `module-blazor` 模板创建模块
+- **AND** 创建包含 `MyModule.Core` 与 `MyModule.UI.Blazor` 的解决方案
+
+#### Scenario: List templates
+- **WHEN** 用户执行 `modulus new --list`
+- **THEN** 系统输出可用模板列表（至少包含 `module-avalonia` 与 `module-blazor`）
+- **AND** 命令退出码为 0
+- **AND** 不创建任何文件或目录
+
+#### Scenario: Removed legacy options are rejected
+- **WHEN** 用户执行 `modulus new MyModule --target avalonia`
+- **THEN** 系统提示参数不受支持（legacy options removed）
+- **AND** 命令退出码为非 0
+
+

--- a/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/tasks.md
+++ b/openspec/changes/archive/2025-12-17-refactor-modulus-new-command/tasks.md
@@ -1,0 +1,12 @@
+## 1. Spec
+- [x] 1.1 Update `module-template` spec delta for new `modulus new` syntax and removed options
+- [x] 1.2 Update `cli-testing` spec delta to use new syntax in `New command creates module` scenario
+- [x] 1.3 Run `openspec validate refactor-modulus-new-command --strict`
+
+## 2. Implementation (after approval)
+- [x] 2.1 Refactor `src/Modulus.Cli/Commands/NewCommand.cs` to accept `[<template>] -n <name> ...` and `--list`
+- [x] 2.2 Remove deleted options and update help text / exit codes
+- [x] 2.3 Update CLI integration tests (`CliRunner` + `NewCommandTests`) to new syntax
+- [x] 2.4 Update docs command examples (`docs/*`, `README*`) to new syntax
+
+

--- a/openspec/specs/cli-testing/spec.md
+++ b/openspec/specs/cli-testing/spec.md
@@ -2,9 +2,7 @@
 
 ## Purpose
 CLI 集成测试规范，定义 CLI 命令的测试环境隔离、数据库一致性和全生命周期验证。本规范同时规定测试目录布局、数据清理策略与失败诊断输出要求，以确保测试可重复与可追溯。
-
 ## Requirements
-
 ### Requirement: CLI Test Environment Isolation
 
 CLI 集成测试 SHALL 在隔离环境中运行，不影响真实用户数据。
@@ -39,38 +37,32 @@ CLI 集成测试 SHALL 在隔离环境中运行，不影响真实用户数据。
 CLI 集成测试 SHALL 覆盖所有 CLI 命令的基本功能。
 
 #### Scenario: New command creates module
-
-- **WHEN** 执行 `modulus new TestModule -t avalonia --force`
+- **WHEN** 执行 `modulus new -n TestModule --force`
 - **THEN** 创建包含正确结构的模块目录
 - **AND** 生成 `.sln`、`.csproj`、`extension.vsixmanifest` 等文件
 
 #### Scenario: Build command compiles module
-
 - **WHEN** 在模块目录执行 `modulus build`
 - **THEN** 编译成功并生成 DLL 文件
 - **AND** 返回退出码 0
 
 #### Scenario: Pack command creates package
-
 - **WHEN** 在模块目录执行 `modulus pack`
 - **THEN** 生成 `.modpkg` 文件
 - **AND** 包内包含 `extension.vsixmanifest` 和模块 DLL
 
 #### Scenario: Install command registers module
-
 - **WHEN** 执行 `modulus install <path>.modpkg`
 - **THEN** 解压包到模块目录
 - **AND** 在数据库中注册模块
 - **AND** `modulus list` 显示已安装模块
 
 #### Scenario: Uninstall command removes module
-
 - **WHEN** 执行 `modulus uninstall <name> --force`
 - **THEN** 从数据库中删除模块记录
 - **AND** `modulus list` 不再显示该模块
 
 #### Scenario: List command shows installed modules
-
 - **WHEN** 已安装模块后执行 `modulus list`
 - **THEN** 显示模块名称和版本
 - **WHEN** 执行 `modulus list --verbose`

--- a/openspec/specs/module-template/spec.md
+++ b/openspec/specs/module-template/spec.md
@@ -2,9 +2,7 @@
 
 ## Purpose
 模块项目模板规范，定义 Visual Studio 模板和 CLI 模板命令的行为。本规范覆盖生成文件结构、默认依赖、可编译性与清单有效性等最低保障，以避免模板漂移导致的创建失败或编译失败。
-
 ## Requirements
-
 ### Requirement: Visual Studio Project Template
 
 系统 SHALL 提供 Visual Studio 多项目模板，支持通过 VS 向导创建 Modulus 模块。
@@ -27,20 +25,28 @@
 
 ### Requirement: CLI Template Command
 
-系统 SHALL 提供 `modulus new` CLI 命令，用于创建 Modulus 模块。
+系统 SHALL 提供 `modulus new` CLI 命令，用于创建 Modulus 模块，并遵循 `dotnet new` 的最佳实践：以模板选择为主、以通用参数为辅，避免暴露模板内部元数据参数。
 
-#### Scenario: CLI 向导模式创建模块
+#### Scenario: Default template is module-avalonia
+- **WHEN** 用户执行 `modulus new -n MyModule`
+- **THEN** 系统使用 `module-avalonia` 模板创建模块
+- **AND** 创建包含 `MyModule.Core` 与 `MyModule.UI.Avalonia` 的解决方案
 
-- **WHEN** 用户执行 `modulus new MyModule`，且未提供 `--target` 参数
-- **THEN** 系统进入交互式向导模式
-- **AND** 提示用户选择目标 Host（Avalonia 或 Blazor）
-- **AND** 提示用户输入可选信息（显示名称、描述等）
+#### Scenario: Explicit template creates module
+- **WHEN** 用户执行 `modulus new module-blazor -n MyModule`
+- **THEN** 系统使用 `module-blazor` 模板创建模块
+- **AND** 创建包含 `MyModule.Core` 与 `MyModule.UI.Blazor` 的解决方案
 
-#### Scenario: CLI 批处理模式创建模块
+#### Scenario: List templates
+- **WHEN** 用户执行 `modulus new --list`
+- **THEN** 系统输出可用模板列表（至少包含 `module-avalonia` 与 `module-blazor`）
+- **AND** 命令退出码为 0
+- **AND** 不创建任何文件或目录
 
+#### Scenario: Removed legacy options are rejected
 - **WHEN** 用户执行 `modulus new MyModule --target avalonia`
-- **THEN** 系统直接使用提供的参数值创建项目
-- **AND** 未提供的可选参数使用默认值
+- **THEN** 系统提示参数不受支持（legacy options removed）
+- **AND** 命令退出码为非 0
 
 ### Requirement: Module Project Structure
 

--- a/src/Modules/Home/Home.Core/ViewModels/HomeViewModel.cs
+++ b/src/Modules/Home/Home.Core/ViewModels/HomeViewModel.cs
@@ -72,7 +72,7 @@ public partial class HomeViewModel : ViewModelBase
     /// </summary>
     public IReadOnlyList<CliCommand> QuickStartCommands { get; } =
     [
-        new("Create a new module", "modulus new MyModule -t avalonia"),
+        new("Create a new module", "modulus new -n MyModule"),
         new("Build all modules", "modulus build"),
         new("Run with hot reload", "modulus run --watch"),
         new("Install a module", "modulus install ./MyModule.modpkg")

--- a/src/Modulus.UI.Avalonia/Themes/Controls/CliTerminal.axaml
+++ b/src/Modulus.UI.Avalonia/Themes/Controls/CliTerminal.axaml
@@ -7,7 +7,7 @@
             <controls:CliTerminal Title="Terminal — Quick Start">
                 <controls:CliTerminal.Commands>
                     <x:Array Type="{x:Type x:String}">
-                        <x:String>modulus new MyModule -t avalonia</x:String>
+                        <x:String>modulus new -n MyModule</x:String>
                         <x:String>modulus build</x:String>
                     </x:Array>
                 </controls:CliTerminal.Commands>

--- a/tests/Modulus.Cli.IntegrationTests/Commands/BuildCommandTests.cs
+++ b/tests/Modulus.Cli.IntegrationTests/Commands/BuildCommandTests.cs
@@ -20,7 +20,7 @@ public class BuildCommandTests : IDisposable
     public async Task Build_ValidModule_Succeeds()
     {
         // Arrange - Create a new module first
-        var newResult = await _runner.NewAsync("BuildTest", "avalonia");
+        var newResult = await _runner.NewAsync("BuildTest", force: true);
         Assert.True(newResult.IsSuccess, $"Failed to create module: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, "BuildTest");
@@ -37,7 +37,7 @@ public class BuildCommandTests : IDisposable
     public async Task Build_Debug_Configuration_Succeeds()
     {
         // Arrange
-        var newResult = await _runner.NewAsync("DebugBuild", "avalonia");
+        var newResult = await _runner.NewAsync("DebugBuild", force: true);
         Assert.True(newResult.IsSuccess, $"Failed to create module: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, "DebugBuild");
@@ -82,7 +82,7 @@ public class BuildCommandTests : IDisposable
     public async Task Build_Verbose_ShowsDetails()
     {
         // Arrange
-        var newResult = await _runner.NewAsync("VerboseBuild", "avalonia");
+        var newResult = await _runner.NewAsync("VerboseBuild", force: true);
         Assert.True(newResult.IsSuccess, $"Failed to create module: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, "VerboseBuild");

--- a/tests/Modulus.Cli.IntegrationTests/Commands/NewCommandTests.cs
+++ b/tests/Modulus.Cli.IntegrationTests/Commands/NewCommandTests.cs
@@ -20,7 +20,7 @@ public class NewCommandTests : IDisposable
     public async Task New_Avalonia_CreatesModuleSuccessfully()
     {
         // Act
-        var result = await _runner.NewAsync("TestModule", "avalonia");
+        var result = await _runner.NewAsync("TestModule");
         
         // Assert
         Assert.True(result.IsSuccess, $"Command failed: {result.CombinedOutput}");
@@ -41,7 +41,7 @@ public class NewCommandTests : IDisposable
     public async Task New_Blazor_CreatesModuleSuccessfully()
     {
         // Act
-        var result = await _runner.NewAsync("BlazorModule", "blazor");
+        var result = await _runner.NewAsync("BlazorModule", template: "module-blazor");
         
         // Assert
         Assert.True(result.IsSuccess, $"Command failed: {result.CombinedOutput}");
@@ -63,7 +63,7 @@ public class NewCommandTests : IDisposable
         var outputDir = _context.CreateSubDirectory("custom-output");
         
         // Act
-        var result = await _runner.NewAsync("CustomModule", "avalonia", outputPath: outputDir);
+        var result = await _runner.NewAsync("CustomModule", outputPath: outputDir);
         
         // Assert
         Assert.True(result.IsSuccess, $"Command failed: {result.CombinedOutput}");
@@ -82,7 +82,7 @@ public class NewCommandTests : IDisposable
         _context.CreateFile("ExistingModule/old-file.txt", "old content");
         
         // Act
-        var result = await _runner.NewAsync("ExistingModule", "avalonia", force: true);
+        var result = await _runner.NewAsync("ExistingModule", force: true);
         
         // Assert
         Assert.True(result.IsSuccess, $"Command failed: {result.CombinedOutput}");
@@ -96,24 +96,22 @@ public class NewCommandTests : IDisposable
     public async Task New_InvalidName_Fails()
     {
         // Act - lowercase name is invalid
-        var result = await _runner.NewAsync("invalidname", "avalonia");
+        var result = await _runner.NewAsync("invalidname");
         
         // Assert
-        // The CLI currently doesn't return non-zero exit code for this,
-        // so we check for error message in output
+        Assert.False(result.IsSuccess, "Command should fail for invalid module name");
         Assert.Contains("PascalCase", result.CombinedOutput);
     }
     
     [Fact]
-    public async Task New_InvalidTarget_Fails()
+    public async Task New_InvalidTemplate_Fails()
     {
         // Act
-        var result = await _runner.NewAsync("TestModule", "invalid-target");
+        var result = await _runner.NewAsync("TestModule", template: "invalid-template");
         
         // Assert
-        // The CLI currently doesn't return non-zero exit code for this,
-        // so we check for error message in output
-        Assert.Contains("Invalid target", result.CombinedOutput);
+        Assert.False(result.IsSuccess, "Command should fail for invalid template");
+        Assert.Contains("module-avalonia", result.CombinedOutput);
     }
     
     public void Dispose()

--- a/tests/Modulus.Cli.IntegrationTests/Commands/PackCommandTests.cs
+++ b/tests/Modulus.Cli.IntegrationTests/Commands/PackCommandTests.cs
@@ -21,7 +21,7 @@ public class PackCommandTests : IDisposable
     public async Task Pack_ValidModule_CreatesPackage()
     {
         // Arrange - Create and build a module
-        var newResult = await _runner.NewAsync("PackTest", "avalonia");
+        var newResult = await _runner.NewAsync("PackTest", force: true);
         Assert.True(newResult.IsSuccess, $"Failed to create module: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, "PackTest");
@@ -43,7 +43,7 @@ public class PackCommandTests : IDisposable
     public async Task Pack_WithNoBuild_UsesExistingBuild()
     {
         // Arrange - Create, build, then pack with --no-build
-        var newResult = await _runner.NewAsync("NoBuildPack", "avalonia");
+        var newResult = await _runner.NewAsync("NoBuildPack", force: true);
         Assert.True(newResult.IsSuccess, $"Failed to create module: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, "NoBuildPack");
@@ -64,7 +64,7 @@ public class PackCommandTests : IDisposable
     public async Task Pack_PackageContentsValid()
     {
         // Arrange
-        var newResult = await _runner.NewAsync("ContentCheck", "avalonia");
+        var newResult = await _runner.NewAsync("ContentCheck", force: true);
         Assert.True(newResult.IsSuccess, $"Failed to create module: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, "ContentCheck");
@@ -102,7 +102,7 @@ public class PackCommandTests : IDisposable
     public async Task Pack_BlazorModule_CreatesPackage()
     {
         // Arrange
-        var newResult = await _runner.NewAsync("BlazorPack", "blazor");
+        var newResult = await _runner.NewAsync("BlazorPack", template: "module-blazor", force: true);
         Assert.True(newResult.IsSuccess, $"Failed to create module: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, "BlazorPack");

--- a/tests/Modulus.Cli.IntegrationTests/EndToEnd/FullLifecycleTests.cs
+++ b/tests/Modulus.Cli.IntegrationTests/EndToEnd/FullLifecycleTests.cs
@@ -20,19 +20,19 @@ public class FullLifecycleTests : IDisposable
     [Fact]
     public async Task FullLifecycle_Avalonia_CompletesSuccessfully()
     {
-        await RunFullLifecycleTest("AvaloniaLifecycle", "avalonia");
+        await RunFullLifecycleTest("AvaloniaLifecycle", template: null);
     }
     
     [Fact]
     public async Task FullLifecycle_Blazor_CompletesSuccessfully()
     {
-        await RunFullLifecycleTest("BlazorLifecycle", "blazor");
+        await RunFullLifecycleTest("BlazorLifecycle", template: "module-blazor");
     }
     
-    private async Task RunFullLifecycleTest(string moduleName, string target)
+    private async Task RunFullLifecycleTest(string moduleName, string? template)
     {
         // Step 1: Create new module
-        var newResult = await _runner.NewAsync(moduleName, target);
+        var newResult = await _runner.NewAsync(moduleName, template: template, force: true);
         Assert.True(newResult.IsSuccess, $"[new] Failed: {newResult.CombinedOutput}");
         Assert.Contains($"Created {moduleName}.sln", newResult.StandardOutput);
         
@@ -84,7 +84,7 @@ public class FullLifecycleTests : IDisposable
         var moduleName = "ReinstallTest";
         
         // Create and pack module
-        var newResult = await _runner.NewAsync(moduleName, "avalonia");
+        var newResult = await _runner.NewAsync(moduleName, force: true);
         Assert.True(newResult.IsSuccess, $"[new] Failed: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, moduleName);
@@ -123,7 +123,7 @@ public class FullLifecycleTests : IDisposable
         var moduleName = "UpdateTest";
         
         // Create, pack and install version 1
-        var newResult = await _runner.NewAsync(moduleName, "avalonia");
+        var newResult = await _runner.NewAsync(moduleName, force: true);
         Assert.True(newResult.IsSuccess, $"[new] Failed: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, moduleName);

--- a/tests/Modulus.Cli.IntegrationTests/EndToEnd/ModuleLoadTests.cs
+++ b/tests/Modulus.Cli.IntegrationTests/EndToEnd/ModuleLoadTests.cs
@@ -24,7 +24,7 @@ public class ModuleLoadTests : IDisposable
     {
         // Arrange - Create and pack a module
         var moduleName = "LoadableAvalonia";
-        var newResult = await _runner.NewAsync(moduleName, "avalonia");
+        var newResult = await _runner.NewAsync(moduleName, force: true);
         Assert.True(newResult.IsSuccess, $"[new] Failed: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, moduleName);
@@ -50,7 +50,7 @@ public class ModuleLoadTests : IDisposable
     {
         // Arrange
         var moduleName = "LoadableBlazor";
-        var newResult = await _runner.NewAsync(moduleName, "blazor");
+        var newResult = await _runner.NewAsync(moduleName, template: "module-blazor", force: true);
         Assert.True(newResult.IsSuccess, $"[new] Failed: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, moduleName);
@@ -76,7 +76,7 @@ public class ModuleLoadTests : IDisposable
     {
         // Arrange
         var moduleName = "ManifestCheck";
-        var newResult = await _runner.NewAsync(moduleName, "avalonia");
+        var newResult = await _runner.NewAsync(moduleName, force: true);
         Assert.True(newResult.IsSuccess, $"[new] Failed: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, moduleName);
@@ -111,7 +111,7 @@ public class ModuleLoadTests : IDisposable
     {
         // Arrange
         var moduleName = "DllCheck";
-        var newResult = await _runner.NewAsync(moduleName, "avalonia");
+        var newResult = await _runner.NewAsync(moduleName, force: true);
         Assert.True(newResult.IsSuccess, $"[new] Failed: {newResult.CombinedOutput}");
         
         var moduleDir = Path.Combine(_context.WorkingDirectory, moduleName);

--- a/tests/Modulus.Cli.IntegrationTests/Infrastructure/CliRunner.cs
+++ b/tests/Modulus.Cli.IntegrationTests/Infrastructure/CliRunner.cs
@@ -95,11 +95,16 @@ public class CliRunner
     /// </summary>
     public Task<CliResult> NewAsync(
         string moduleName, 
-        string target, 
+        string? template = null,
         string? outputPath = null,
         bool force = false)
     {
-        var args = $"new {moduleName} --target {target}";
+        var args = "new";
+        if (!string.IsNullOrWhiteSpace(template))
+        {
+            args += $" {template}";
+        }
+        args += $" --name {moduleName}";
         if (!string.IsNullOrEmpty(outputPath))
         {
             args += $" --output \"{outputPath}\"";


### PR DESCRIPTION
BREAKING: remove legacy new options; add --list and default module-avalonia; update tests/docs/specs
