### PR TITLE
Validate module package host compatibility on install

### DIFF
--- a/src/Hosts/Modulus.Host.Blazor/Components/Pages/Modules.razor
+++ b/src/Hosts/Modulus.Host.Blazor/Components/Pages/Modules.razor
@@ -10,7 +10,7 @@
 @if (!string.IsNullOrEmpty(ViewModel.ErrorMessage))
 {
     <MudAlert Severity="Severity.Error" Class="mb-4" ShowCloseIcon="true" CloseIconClicked="@(() => ViewModel.ErrorMessage = null)">
-        @ViewModel.ErrorMessage
+        <MudText Typo="Typo.body2" Style="white-space: pre-line">@ViewModel.ErrorMessage</MudText>
     </MudAlert>
 }
 

--- a/src/Hosts/Modulus.Host.Blazor/Shell/ViewModels/ModuleListViewModel.cs
+++ b/src/Hosts/Modulus.Host.Blazor/Shell/ViewModels/ModuleListViewModel.cs
@@ -316,7 +316,9 @@ public partial class ModuleListViewModel : ObservableObject
 
             if (!result.Success)
             {
-                ErrorMessage = result.Error ?? "Installation failed.";
+                ErrorMessage =
+                    result.Error ??
+                    "Installation failed. The selected package may not be compatible with this host.";
                 IsLoading = false;
                 return;
             }

--- a/src/Modules/Home/Home.UI.Blazor/HomePage.razor.css
+++ b/src/Modules/Home/Home.UI.Blazor/HomePage.razor.css
@@ -7,16 +7,8 @@
     margin: 0 auto;
 }
 
-/* Theme backgrounds */
-.home-container.dark-theme {
-    background: linear-gradient(135deg, #0a0a0f 0%, #12121a 100%);
-    color: #e8e8e8;
-}
-
-.home-container.light-theme {
-    background: linear-gradient(135deg, #E8DBFF 0%, #D4C4F0 50%, #C9B8E8 100%);
-    color: #1a1a1a;
-}
+/* Theme backgrounds
+   Intentionally NOT setting page background here. The host app owns the content background. */
 
 .loading-container {
     display: flex;

--- a/src/Modulus.UI.Avalonia/Controls/MessageDialog/MessageDialog.cs
+++ b/src/Modulus.UI.Avalonia/Controls/MessageDialog/MessageDialog.cs
@@ -195,21 +195,28 @@ public class MessageDialog : Window
         contentPanel.Children.Add(buttonPanel);
 
         // Message
+        // Use read-only TextBox so multi-line diagnostics render reliably and users can copy details.
+        var messageBox = new TextBox
+        {
+            Text = _message.Replace("\r\n", "\n"),
+            IsReadOnly = true,
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 14,
+            Foreground = new SolidColorBrush(MessageTextColor),
+            Background = Brushes.Transparent,
+            BorderThickness = new Thickness(0),
+            MinHeight = 60
+        };
+
         var messageScroll = new ScrollViewer
         {
             MaxHeight = 200,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            Content = messageBox
         };
 
-        var messageText = new TextBlock
-        {
-            Text = _message,
-            TextWrapping = TextWrapping.Wrap,
-            FontSize = 14,
-            Foreground = new SolidColorBrush(MessageTextColor)
-        };
-
-        messageScroll.Content = messageText;
         contentPanel.Children.Add(messageScroll);
 
         contentBorder.Child = contentPanel;

--- a/tests/Modulus.Core.Tests/Installation/ModuleInstallerServicePackageHostValidationTests.cs
+++ b/tests/Modulus.Core.Tests/Installation/ModuleInstallerServicePackageHostValidationTests.cs
@@ -1,0 +1,86 @@
+using System.IO.Compression;
+using Microsoft.Extensions.Logging;
+using Modulus.Core.Installation;
+using Modulus.Core.Manifest;
+using Modulus.Infrastructure.Data.Repositories;
+using Modulus.Sdk;
+using NSubstitute;
+
+namespace Modulus.Core.Tests.Installation;
+
+public class ModuleInstallerServicePackageHostValidationTests
+{
+    [Fact]
+    public async Task InstallFromPackageAsync_WhenHostNotSupported_ReturnsFailed_AndDoesNotWriteDb()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "ModulusTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        var packageDir = Path.Combine(tempRoot, "pkg");
+        Directory.CreateDirectory(packageDir);
+
+        // Create a minimal package layout: manifest + one dll (core)
+        File.WriteAllBytes(Path.Combine(packageDir, "Test.Core.dll"), Array.Empty<byte>());
+        WriteManifest(
+            packageDir,
+            moduleId: Guid.NewGuid().ToString(),
+            supportedHostId: ModulusHostIds.Avalonia,
+            hostSpecificUiDllName: "Test.UI.Avalonia.dll",
+            hostSpecificUiHostId: ModulusHostIds.Avalonia);
+        File.WriteAllBytes(Path.Combine(packageDir, "Test.UI.Avalonia.dll"), Array.Empty<byte>());
+
+        var modpkgPath = Path.Combine(tempRoot, "Test.modpkg");
+        ZipFile.CreateFromDirectory(packageDir, modpkgPath);
+
+        var moduleRepo = Substitute.For<IModuleRepository>();
+        var menuRepo = Substitute.For<IMenuRepository>();
+        var cleanup = Substitute.For<IModuleCleanupService>();
+        var logger = Substitute.For<ILogger<ModuleInstallerService>>();
+        var validator = new DefaultManifestValidator(Substitute.For<ILogger<DefaultManifestValidator>>());
+
+        var sut = new ModuleInstallerService(moduleRepo, menuRepo, validator, cleanup, logger);
+
+        var result = await sut.InstallFromPackageAsync(modpkgPath, overwrite: false, hostType: ModulusHostIds.Blazor);
+
+        Assert.False(result.Success);
+        Assert.False(result.RequiresConfirmation);
+        Assert.NotNull(result.Error);
+        Assert.Contains("not compatible", result.Error!, StringComparison.OrdinalIgnoreCase);
+
+        await moduleRepo.DidNotReceiveWithAnyArgs().UpsertAsync(default!, default);
+        await menuRepo.DidNotReceiveWithAnyArgs().ReplaceModuleMenusAsync(default!, default!, default);
+
+        try { Directory.Delete(tempRoot, true); } catch { /* ignore */ }
+    }
+
+    private static void WriteManifest(
+        string moduleDir,
+        string moduleId,
+        string supportedHostId,
+        string hostSpecificUiDllName,
+        string hostSpecificUiHostId)
+    {
+        var manifest =
+            $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<PackageManifest Version=""2.0.0"" xmlns=""http://schemas.microsoft.com/developer/vsx-schema/2011"">
+  <Metadata>
+    <Identity Id=""{moduleId}"" Version=""1.0.0"" Language=""en-US"" Publisher=""Test"" />
+    <DisplayName>Test Module</DisplayName>
+    <Description>Test</Description>
+  </Metadata>
+
+  <Installation>
+    <InstallationTarget Id=""{supportedHostId}"" Version=""[1.0,)"" />
+  </Installation>
+
+  <Assets>
+    <Asset Type=""{ModulusAssetTypes.Package}"" Path=""Test.Core.dll"" />
+    <Asset Type=""{ModulusAssetTypes.Package}"" Path=""{hostSpecificUiDllName}"" TargetHost=""{hostSpecificUiHostId}"" />
+  </Assets>
+</PackageManifest>";
+
+        File.WriteAllText(Path.Combine(moduleDir, SystemModuleInstaller.VsixManifestFileName), manifest);
+    }
+}
+
+


### PR DESCRIPTION
- Fail fast when modpkg targets a different host UI (Blazor vs Avalonia)\n- Require host-specific Modulus.Package with TargetHost==hostType\n- Improve install error rendering in Blazor and Avalonia dialogs\n- Remove Home Blazor page background override\n- Add/adjust tests for host validation
